### PR TITLE
Summer2026

### DIFF
--- a/src/CartView.tsx
+++ b/src/CartView.tsx
@@ -5,16 +5,7 @@ import maplibregl, { GeoJSONSource, Marker, Popup } from "maplibre-gl";
 import GeoJSON, { Position } from "geojson";
 type GeoJSON = GeoJSON.GeoJSON;
 import * as ROSLIB from "roslib";
-import {
-    clicked_point,
-    vehicle_state,
-    visual_path,
-    limited_pose,
-    left_image,
-    stop_topic,
-    nav_cmd,
-    brake_cmd
-} from "./topics";
+import { ros, clicked_point, vehicle_state, visual_path, limited_pose, left_image, stop_topic, nav_cmd, brake_cmd } from "./topics";
 import { Image, ROSMarkerList } from "./MessageTypes";
 import { rosToMapCoords, lngLatToMapCoords } from "./transform";
 import locations from "./locations.json";
@@ -55,6 +46,7 @@ export default function CartView() {
     const [selectedLocation, setSelectedLocation] = useState<{ lat: number, long: number, name: string, displayName: string } | null>(null);
     const [isNewUser, setIsNewUser] = useState(false);
     const [helpRequested, setHelpRequested] = useState(false);
+    const [rosConnected, setRosConnected] = useState(false);
     const { speak } = useTTS();
     const stopIntervalRef = useRef<NodeJS.Timeout | null>(null);
     const [pendingCommandSource, setPendingCommandSource] = useState<CommandSource>("touch");
@@ -65,6 +57,29 @@ export default function CartView() {
         stopped: false,
     });
 
+    useEffect(() => {
+        const handleConnection = () => setRosConnected(true);
+        const handleClose = () => setRosConnected(false);
+        const handleError = () => setRosConnected(false);
+    
+        setRosConnected(ros.isConnected);
+    
+        ros.on("connection", handleConnection);
+        ros.on("close", handleClose);
+        ros.on("error", handleError);
+    
+        const interval = window.setInterval(() => {
+            setRosConnected(ros.isConnected);
+        }, 1000);
+    
+        return () => {
+            ros.off("connection", handleConnection);
+            ros.off("close", handleClose);
+            ros.off("error", handleError);
+            window.clearInterval(interval);
+        };
+    }, []);
+    
     const PIN_COLORS = [
         'red',
         'blue',
@@ -493,14 +508,34 @@ export default function CartView() {
     }, []);
 
     function navigateTo(lat: number, lng: number) {
-        console.log(`Target Coordinates: ${lat}, ${lng}`);
-        const [x, y] = lngLatToMapCoords({ lat, lng });
-        const target = new ROSLIB.Message({
-            point: { x, y, z: 0 },
-        });
-        clicked_point.publish(target);
+      if (!ros.isConnected) {
+        console.error("Cannot publish destination: ROS is not connected");
+        message.error("Cannot navigate: ROS is not connected");
+        return;
+      }
+    
+      console.log(`Target Coordinates: ${lat}, ${lng}`);
+    
+      const [x, y] = lngLatToMapCoords({ lat, lng });
+    
+      const target = new ROSLIB.Message({
+        header: {
+          stamp: {
+            sec: 0,
+            nanosec: 0,
+          },
+          frame_id: "map",
+        },
+        point: {
+          x,
+          y,
+          z: 0,
+        },
+      });
+    
+      console.log("Publishing /clicked_point:", target);
+      clicked_point.publish(target);
     }
-
     function navigateToLocation(location: { lat: number, long: number, name: string, displayName: string }) {
         console.log("Navigating to: " + location.displayName);
         setState(prev => ({ ...prev, is_navigating: true, reached_destination: false }));

--- a/src/locations.json
+++ b/src/locations.json
@@ -26,7 +26,7 @@
     "lat": 38.434257,
     "long": -78.864156,
     "url": "https://map.jmu.edu/?id=1869#!m/576605",
-    "disabled": true
+    "disabled": false
   },
   {
     "name": "paul jennings hall",
@@ -34,7 +34,7 @@
     "lat": 38.430546,
     "long": -78.865645,
     "url": "https://map.jmu.edu/?id=1869#!m/593002",
-    "disabled": true
+    "disabled": false
   },
   {
     "name": "E-hall",
@@ -42,6 +42,6 @@
     "lat": 38.431657,
     "long": -78.860881,
     "url": "https://map.jmu.edu/?id=1869#!m/622822",
-    "disabled": true
+    "disabled": false
   }
 ]

--- a/src/topics.ts
+++ b/src/topics.ts
@@ -1,79 +1,140 @@
 import * as ROSLIB from "roslib";
 
-// ROS Connection
-const ros = new ROSLIB.Ros({
-  url: "ws://localhost:9090",
-});
+const ROSBRIDGE_URL =
+  import.meta.env.VITE_ROSBRIDGE_URL || "ws://127.0.0.1:9090";
+
+const RECONNECT_INTERVAL_MS = 2000;
+
+export const ros = new ROSLIB.Ros({});
+
+let reconnectTimer: number | null = null;
+let manuallyClosed = false;
+
+function scheduleReconnect() {
+  if (manuallyClosed) return;
+  if (reconnectTimer !== null) return;
+
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = null;
+
+    if (!ros.isConnected) {
+      connectToRos();
+    }
+  }, RECONNECT_INTERVAL_MS);
+}
+
+export function connectToRos() {
+  if (ros.isConnected) return;
+
+  console.log("Attempting ROS connection:", ROSBRIDGE_URL);
+
+  try {
+    ros.connect(ROSBRIDGE_URL);
+  } catch (error) {
+    console.error("ROS connect threw error:", error);
+    scheduleReconnect();
+  }
+}
+
+export function disconnectFromRos() {
+  manuallyClosed = true;
+
+  if (reconnectTimer !== null) {
+    window.clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+
+  ros.close();
+}
 
 ros.on("connection", () => {
-  console.log("Connected to ROS");
-  console.log("Available ROS message types:", ros.messageTypes); // Log all available message types
+  console.log("Connected to ROS:", ROSBRIDGE_URL);
+
+  if (reconnectTimer !== null) {
+    window.clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
 });
 
-ros.on("connection", () => console.log("Connected to ROS"));
+ros.on("error", (error) => {
+  console.error("ROS connection error:", error);
+  scheduleReconnect();
+});
 
-// Topics
+ros.on("close", () => {
+  console.warn("ROS connection closed. Retrying...");
+  scheduleReconnect();
+});
+
+// Start initial connection attempt.
+connectToRos();
+
+// Periodic safety check in case the websocket fails silently.
+window.setInterval(() => {
+  if (!ros.isConnected) {
+    console.warn("ROS still disconnected. Retrying connection...");
+    connectToRos();
+  }
+}, 5000);
+
 export const visual_path = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/visual_path",
   messageType: "visualization_msgs/msg/MarkerArray",
 });
 
 export const limited_pose = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/pcl_pose",
   messageType: "geometry_msgs/msg/PoseWithCovarianceStamped",
 });
 
 export const vehicle_state = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/vehicle_state",
   messageType: "navigation_interface/msg/VehicleState",
 });
 
 export const clicked_point = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/clicked_point",
   messageType: "geometry_msgs/msg/PointStamped",
 });
 
 export const right_video = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "right_image",
-  messageType: "sensor_msgs/msg/Image"
+  messageType: "sensor_msgs/msg/Image",
 });
 
 export const left_image = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/zed/zed_node/rgb/image_rect_color",
   messageType: "sensor_msgs/msg/Image",
-  throttle_rate: 150
+  throttle_rate: 150,
 });
 
 export const stop_topic = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/set_manual_control",
-  messageType: "std_msgs/Bool"
+  messageType: "std_msgs/Bool",
 });
 
 export const nav_cmd = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/nav_cmd",
-  messageType: "motor_control_interface/msg/VelAngle"
+  messageType: "motor_control_interface/msg/VelAngle",
 });
 
-// Add direct brake command topic
 export const brake_cmd = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "/direct_brake",
-  messageType: "std_msgs/UInt8"
+  messageType: "std_msgs/UInt8",
 });
 
-/**
- * AI anomaly logging topic
- */
+// ai_anomaly_logging
 export const ai_anomaly_logging = new ROSLIB.Topic({
-  ros: ros,
+  ros,
   name: "ai_anomaly_logging_ui",
   messageType: "std_msgs/String",
 });

--- a/src/topics.ts
+++ b/src/topics.ts
@@ -55,20 +55,29 @@ export function disconnectFromRos() {
 
 ros.on("connection", () => {
   console.log("Connected to ROS");
+  console.log("Available ROS message types:", ros.messageTypes); // Log all available message types
+
+  isConnecting = false;
+
+  if (reconnectTimer !== null) {
+    window.clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
 });
 
 ros.on("error", (error) => {
   console.error("ROS connection error object:", error);
   console.error("ROS URL was:", ROSBRIDGE_URL);
+
+  isConnecting = false;
+  scheduleReconnect();
 });
 
 ros.on("close", (event) => {
   console.warn("ROS connection closed:", event);
-});
 
-ros.on("connection", () => {
-  console.log("Connected to ROS");
-  console.log("Available ROS message types:", ros.messageTypes); // Log all available message types
+  isConnecting = false;
+  scheduleReconnect();
 });
 
 // Start initial connection attempt.

--- a/src/topics.ts
+++ b/src/topics.ts
@@ -8,6 +8,7 @@ const RECONNECT_INTERVAL_MS = 2000;
 export const ros = new ROSLIB.Ros({});
 
 let reconnectTimer: number | null = null;
+let isConnecting = false;
 let manuallyClosed = false;
 
 function scheduleReconnect() {
@@ -17,14 +18,17 @@ function scheduleReconnect() {
   reconnectTimer = window.setTimeout(() => {
     reconnectTimer = null;
 
-    if (!ros.isConnected) {
+    if (!ros.isConnected && !isConnecting) {
       connectToRos();
     }
   }, RECONNECT_INTERVAL_MS);
 }
 
 export function connectToRos() {
-  if (ros.isConnected) return;
+  if (ros.isConnected || isConnecting) return;
+
+  manuallyClosed = false;
+  isConnecting = true;
 
   console.log("Attempting ROS connection:", ROSBRIDGE_URL);
 
@@ -32,12 +36,14 @@ export function connectToRos() {
     ros.connect(ROSBRIDGE_URL);
   } catch (error) {
     console.error("ROS connect threw error:", error);
+    isConnecting = false;
     scheduleReconnect();
   }
 }
 
 export function disconnectFromRos() {
   manuallyClosed = true;
+  isConnecting = false;
 
   if (reconnectTimer !== null) {
     window.clearTimeout(reconnectTimer);
@@ -49,6 +55,7 @@ export function disconnectFromRos() {
 
 ros.on("connection", () => {
   console.log("Connected to ROS:", ROSBRIDGE_URL);
+  isConnecting = false;
 
   if (reconnectTimer !== null) {
     window.clearTimeout(reconnectTimer);
@@ -58,11 +65,13 @@ ros.on("connection", () => {
 
 ros.on("error", (error) => {
   console.error("ROS connection error:", error);
+  isConnecting = false;
   scheduleReconnect();
 });
 
 ros.on("close", () => {
   console.warn("ROS connection closed. Retrying...");
+  isConnecting = false;
   scheduleReconnect();
 });
 
@@ -71,7 +80,7 @@ connectToRos();
 
 // Periodic safety check in case the websocket fails silently.
 window.setInterval(() => {
-  if (!ros.isConnected) {
+  if (!ros.isConnected && !isConnecting) {
     console.warn("ROS still disconnected. Retrying connection...");
     connectToRos();
   }
@@ -135,6 +144,6 @@ export const brake_cmd = new ROSLIB.Topic({
 // ai_anomaly_logging
 export const ai_anomaly_logging = new ROSLIB.Topic({
   ros,
-  name: "ai_anomaly_logging_ui",
+  name: "/ai_anomaly_logging_ui",
   messageType: "std_msgs/String",
 });

--- a/src/topics.ts
+++ b/src/topics.ts
@@ -10,11 +10,12 @@ ros.on("connection", () => {
 });
 
 ros.on("error", (error) => {
-  console.error("ROS connection error:", error);
+  console.error("ROS connection error object:", error);
+  console.error("ROS URL was:", ROSBRIDGE_URL);
 });
 
-ros.on("close", () => {
-  console.warn("ROS connection closed");
+ros.on("close", (event) => {
+  console.warn("ROS connection closed:", event);
 });
 
 ros.on("connection", () => {

--- a/src/topics.ts
+++ b/src/topics.ts
@@ -7,6 +7,18 @@ const ros = new ROSLIB.Ros({
 
 ros.on("connection", () => {
   console.log("Connected to ROS");
+});
+
+ros.on("error", (error) => {
+  console.error("ROS connection error:", error);
+});
+
+ros.on("close", () => {
+  console.warn("ROS connection closed");
+});
+
+ros.on("connection", () => {
+  console.log("Connected to ROS");
   console.log("Available ROS message types:", ros.messageTypes); // Log all available message types
 });
 


### PR DESCRIPTION
# Pull Request

## Linked Issue
Closes N/A

---

# Summary
Adds automatic ROS connection management with reconnection handling, tracks live ROS connection status in `CartView`, guards the navigation publish against a disconnected ROS connection, adds a proper header to the `/clicked_point` message, and enables three previously-disabled destination locations (Paul Jennings Hall, E-Hall, King Hall) in `locations.json`.

---

# Testing Summary

- Testing process: Ran the UI against rosbridge, verified `ros` connects on load via `connectToRos()`, and confirmed the connection status indicator (`rosConnected`) updates correctly on connect/disconnect/error events. Tested `navigateTo` both with rosbridge running (point published successfully to `/clicked_point`) and with rosbridge stopped (navigation blocked with an error message instead of throwing). Selected the three newly enabled locations to confirm they appear and are selectable on the map.
- Observed results: ROS auto-reconnects within ~2 seconds of rosbridge restarting; UI correctly reflects connection state; `/clicked_point` messages now include a populated header with `frame_id: "map"`.
- Edge cases explored: rosbridge unavailable at startup (reconnect loop engages without crashing), rosbridge dropping mid-session (UI flips to disconnected and recovers), rapid navigate clicks while disconnected (no duplicate publishes, error shown each time).

---

# Testing Instructions
Running either ./run.sh or ./dev-run-backend.sh should have the cart UI automatically connect to ROS2


---

# Success Metrics (From Issue)
- [ ] Metric 1: UI automatically connects to rosbridge on load and reconnects after a dropped connection without a page refresh.
- [ ] Metric 2: Navigation commands are not published to `/clicked_point` when ROS is disconnected, and the user is notified in the web devtool console
- [ ] Metric 3: Previously disabled destination locations (Paul Jennings Hall, E-Hall, King Hall) are available for selection in the UI.

---

# Integration Impact
Yes. This affects the ROS2 connection lifecycle shared by all topics defined in `topics.ts` (`visual_path`, `limited_pose`, `vehicle_state`, `clicked_point`, `right_video`, `left_image`, `stop_topic`, `nav_cmd`, `brake_cmd`, `ai_anomaly_logging`), since they now reference a singleton `ros2` instance that connects/reconnects automatically rather than connecting once at import time. The added header on `/clicked_point` messages should be verified against what the navigation stack subscriber expects. The `ai_anomaly_logging` topic name was also changed from `"ai_anomaly_logging_ui"` to `"/ai_anomaly_logging_ui"`, which may need to match the subscribing node's topic name.